### PR TITLE
Fix inline tex state entityKey not updated correctly

### DIFF
--- a/lib/components/InlineTeX.js
+++ b/lib/components/InlineTeX.js
@@ -3,6 +3,7 @@ import { saveInlineTeX } from '../modifiers/saveTeX';
 import { useTeXUtils } from '../utils/useTeXUtils';
 import TeX from './TeX';
 import TeXInput from './TeXInput';
+
 const getInitialState = (contentState, entityKey) => {
     const entity = contentState.getEntity(entityKey);
     const { tex, type } = entity.getData();
@@ -12,6 +13,7 @@ const getInitialState = (contentState, entityKey) => {
         type
     };
 };
+
 function InlineTeX({ children, contentState, entityKey, offsetKey, store, internals }) {
     const { state, setState, getCaretPos, submitTeX, onClickEdit } = useTeXUtils(getInitialState.bind(null, contentState, entityKey), store, internals, entityKey);
     const finishEditing = useCallback((after) => {
@@ -30,6 +32,18 @@ function InlineTeX({ children, contentState, entityKey, offsetKey, store, intern
         });
         submitTeX(newContentState, newSelection, needsRemoval);
     }, [children, contentState, entityKey, offsetKey, setState, state, submitTeX]);
+
+    useEffect(() => {
+        // In case entitymap is updated, this should update the component's state
+        const entity = contentState.getEntity(entityKey);
+        const { tex, type } = entity.getData();
+        setState({
+            editing: tex.length === 0,
+            tex,
+            type
+        });
+    }, [contentState, entityKey]);
+
     return (React.createElement("span", { className: `draft-js-modules-katex INLINETEX${state.editing ? ' editing' : ''}` },
         state.editing && (React.createElement(TeXInput, { state: state, setState: setState, getCaretPos: getCaretPos, finishEditing: finishEditing })),
         React.createElement(TeX, { state: state, onClick: onClickEdit, "data-offset-key": offsetKey })));


### PR DESCRIPTION
Fixing issue whereby Editor entityMap is updated, but the InlineTex components are not rerendered, because changing entityKeys do not trigger a state change.